### PR TITLE
Updating Travis-CI and fixing DESCRIPTION

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^data-raw$
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+sudo: false
+cache: packages
+warnings_are_errors: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,4 +8,5 @@ Description: Interface to use and access the GAMA simulation platform from R
     using the headless mode.
 License: MIT
 LazyData: TRUE
+Imports: XML, dplyr, plyr
 RoxygenNote: 6.0.1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# gamar
+[![Travis-CI Build Status](https://travis-ci.org/thanhleviet/gamar3.svg?branch=master)](https://travis-ci.org/thanhleviet/gamar3)
+
+## Installation
+
+You can install gamar from github with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("thanhleviet/gamar3")
+```


### PR DESCRIPTION
Configured Travis-CI so that: Travis will ignore warning from building process as errors, not checking vignettes, documents yet
Added Imports for dependencies in DESCRIPTION, otherwise, the checking process will return error